### PR TITLE
Adding more HTTP log fields

### DIFF
--- a/cmd/github-responder/logger.go
+++ b/cmd/github-responder/logger.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	stdlog "log"
 	"os"
 
 	"github.com/rs/zerolog"
@@ -10,8 +11,20 @@ import (
 
 func initLogger() {
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+
+	stdlogger := log.With().Bool("stdlog", true).Logger()
+	stdlog.SetFlags(0)
+	stdlog.SetOutput(stdlogger)
+
 	if terminal.IsTerminal(int(os.Stdout.Fd())) {
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: "15:04:05"})
+
+		noLevelWriter := zerolog.ConsoleWriter{
+			Out:         os.Stderr,
+			FormatLevel: func(i interface{}) string { return "" },
+		}
+		stdlogger = stdlogger.Output(noLevelWriter)
+		stdlog.SetOutput(stdlogger)
 	}
 }
 

--- a/responder.go
+++ b/responder.go
@@ -56,6 +56,7 @@ func Start(ctx context.Context, opts Config, action HookHandler) (func(), error)
 			hlog.RefererHandler("referer"),
 			hlog.MethodHandler("method"),
 			hlog.URLHandler("url"),
+			hlog.RemoteAddrHandler("remoteAddr"),
 		)
 		c = c.Append(hlog.AccessHandler(func(r *http.Request, status, size int, duration time.Duration) {
 			eventType := github.WebHookType(r)
@@ -70,8 +71,7 @@ func Start(ctx context.Context, opts Config, action HookHandler) (func(), error)
 				Dur("duration", duration).
 				Str("eventType", eventType).
 				Str("deliveryID", deliveryID).
-				Msg("-")
-
+				Msgf("%s %s - %d", r.Method, r.URL, status)
 		}))
 		http.Handle(getPath(opts.CallbackURL), c.Then(&callbackHandler{[]byte(opts.HookSecret), action}))
 		http.Handle("/", c.ThenFunc(denyHandler))


### PR DESCRIPTION
- adding `remoteAddr` log field
- using zerolog for stdlib `log` package - certmagic and lego both use this

Signed-off-by: Dave Henderson <dhenderson@gmail.com>