### PR TITLE
New --env flag

### DIFF
--- a/cmd/github-responder/actions.go
+++ b/cmd/github-responder/actions.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	responder "github.com/hairyhenderson/github-responder"
 	"github.com/rs/zerolog/log"
@@ -31,20 +32,22 @@ func defaultAction(ctx context.Context, eventType, deliveryID string, payload []
 	fmt.Println(string(pretty))
 }
 
-func execArgs(args ...string) responder.HookHandler {
+func execArgs(env []string, args ...string) responder.HookHandler {
 	return func(ctx context.Context, eventType, deliveryID string, payload []byte) {
 		log := log.Ctx(ctx)
 		name := args[0]
 		cmdArgs := args[1:]
 		cmdArgs = append(cmdArgs, eventType, deliveryID)
+		input := bytes.NewBuffer(payload)
+		// nolint: gosec
+		c := exec.Command(name, cmdArgs...)
+		c.Env = resolveEnv(env)
 		log.Debug().
 			Int("size", len(payload)).
 			Str("command", name).
 			Strs("args", cmdArgs).
+			Strs("env", keys(c.Env)).
 			Msg("Received event, executing command")
-		input := bytes.NewBuffer(payload)
-		// nolint: gosec
-		c := exec.Command(name, cmdArgs...)
 		c.Stdin = input
 		c.Stderr = os.Stderr
 		c.Stdout = os.Stdout
@@ -53,4 +56,30 @@ func execArgs(args ...string) responder.HookHandler {
 			log.Error().Err(err).Msg(err.Error())
 		}
 	}
+}
+
+func keys(kvPairs []string) []string {
+	out := make([]string, len(kvPairs))
+	for i, kv := range kvPairs {
+		parts := strings.SplitN(kv, "=", 2)
+		out[i] = parts[0]
+	}
+	return out
+}
+
+func resolveEnv(kvPairs []string) []string {
+	if len(kvPairs) == 0 {
+		return os.Environ()
+	}
+
+	out := make([]string, len(kvPairs))
+	for i, kv := range kvPairs {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) == 1 {
+			out[i] = parts[0] + "=" + os.Getenv(parts[0])
+		} else {
+			out[i] = kv
+		}
+	}
+	return out
 }

--- a/cmd/github-responder/actions_test.go
+++ b/cmd/github-responder/actions_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeys(t *testing.T) {
+	expected := []string{"foo", "bar", "baz"}
+	pairs := []string{"foo=1", "bar=2", "baz"}
+	assert.EqualValues(t, expected, keys(pairs))
+}
+
+func TestResolveEnv(t *testing.T) {
+	expected := []string{"foo=1", "bar=2", "baz=", "USER=" + os.Getenv("USER")}
+	pairs := []string{"foo=1", "bar=2", "baz", "USER"}
+	assert.EqualValues(t, expected, resolveEnv(pairs))
+
+	assert.EqualValues(t, os.Environ(), resolveEnv(nil))
+	assert.EqualValues(t, os.Environ(), resolveEnv([]string{}))
+}

--- a/cmd/github-responder/main.go
+++ b/cmd/github-responder/main.go
@@ -24,6 +24,7 @@ var (
 	verbose  bool
 	repos    []string
 	events   []string
+	env      []string
 	domain   string
 )
 
@@ -55,7 +56,7 @@ func newCmd() *cobra.Command {
 
 			var action responder.HookHandler
 			if len(args) > 0 {
-				action = execArgs(args...)
+				action = execArgs(env, args...)
 			} else {
 				log.Info().Msg("No action command given, will perform default")
 				action = defaultAction
@@ -85,6 +86,8 @@ func initFlags(command *cobra.Command) {
 	command.Flags().StringVarP(&domain, "domain", "d", "", "domain to serve - a cert will be acquired for this domain")
 	command.Flags().StringVarP(&certmagic.Email, "email", "m", "", "Email used for registration and recovery contact (optional, but recommended)")
 	command.Flags().StringVar(&certmagic.CA, "ca", certmagic.LetsEncryptProductionCA, "URL to certificate authority's ACME server directory. Change this to point to a different server for testing.")
+
+	command.Flags().StringArrayVar(&env, "env", []string{}, "Set environment variables in KEY=value form. Omit =value to inherit current KEY value. By default, actions are executed with the parent environment.")
 
 	command.Flags().BoolVarP(&verbose, "verbose", "V", false, "Output extra logs")
 	command.Flags().BoolVarP(&printVer, "version", "v", false, "Print the version")


### PR DESCRIPTION
Allows scoping environment variables with `--env`

Signed-off-by: Dave Henderson <dhenderson@gmail.com>